### PR TITLE
feat: Add dolphin-tool support for Wii/GameCube disc compression

### DIFF
--- a/compressors/dolphin-tool.lua
+++ b/compressors/dolphin-tool.lua
@@ -12,6 +12,10 @@ local function checkFunction()
 	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false) then
 		return "system"
 	else
+		logSystem.log(
+			"error",
+			"dolphin-tool can't be provided by your system or locally. Wii/GameCube disc image support won't be available."
+		)
 		return "unavailable"
 	end
 end

--- a/compressors/dolphin-tool.lua
+++ b/compressors/dolphin-tool.lua
@@ -1,0 +1,34 @@
+-- Custom modules
+local logSystem = require("modules.logSystem")
+local Compressor = require("modules.compressorObject")
+local compressorManager = require("modules.compressorManager")
+local fsUtils = require("modules.fsUtils")
+
+-- Definitions
+local compressorName = "dolphin-tool"
+local localVersion = nil
+
+local function checkFunction()
+	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false) then
+		return "system"
+	else
+		return "unavailable"
+	end
+end
+
+local function compressFunction(input)
+	logSystem.log("info", "Compressing "..input.." using dolphin-tool.")
+	os.execute(compressorManager.selectCompressionTool("dolphin-tool").." convert -f rvz -c lzma2 -l 9 -b 2097152 -i '"..input.."' -o '"..fsUtils.getDirectory(input).."/"..fsUtils.getFileNameNoExt(input)..".rvz'")
+	os.execute("rm '"..input.."'")
+	return "success"
+end
+
+local function decompressFunction(input)
+	logSystem.log("info", "Decompressing "..input.." using dolphin-tool.")
+	os.execute(compressorManager.selectCompressionTool("dolphin-tool").." convert -f iso -i '"..input.."' -o '"..fsUtils.getDirectory(input).."/"..fsUtils.getFileNameNoExt(input)..".iso'")
+	os.execute("rm '"..input.."'")
+	return "success"
+end
+
+
+return Compressor:new(compressorName, checkFunction, compressFunction, decompressFunction)

--- a/compressors/dolphin-tool.lua
+++ b/compressors/dolphin-tool.lua
@@ -18,17 +18,36 @@ end
 
 local function compressFunction(input)
 	logSystem.log("info", "Compressing "..input.." using dolphin-tool.")
-	os.execute(compressorManager.selectCompressionTool("dolphin-tool").." convert -f rvz -c lzma2 -l 9 -b 2097152 -i '"..input.."' -o '"..fsUtils.getDirectory(input).."/"..fsUtils.getFileNameNoExt(input)..".rvz'")
+
+	local command = string.format("%s convert -f rvz -c lzma2 -l 9 -b 2097152 -i '%s' -o '%s'",
+		compressorManager.selectCompressionTool("dolphin-tool"),
+		input:gsub("'", "'\\''"),
+		(fsUtils.getDirectory(input).."/"..fsUtils.getFileNameNoExt(input)..".rvz"):gsub("'", "'\\''")
+	)
+	logSystem.log("debug", "Running command : "..command)
+	os.execute(command)
+	
+	logSystem.log("debug", "Deleting ISO file...")
 	os.execute("rm '"..input.."'")
+
 	return "success"
 end
 
 local function decompressFunction(input)
 	logSystem.log("info", "Decompressing "..input.." using dolphin-tool.")
-	os.execute(compressorManager.selectCompressionTool("dolphin-tool").." convert -f iso -i '"..input.."' -o '"..fsUtils.getDirectory(input).."/"..fsUtils.getFileNameNoExt(input)..".iso'")
+
+	local command = string.format("%s convert -f iso -i '%s' -o '%s'",
+		compressorManager.selectCompressionTool("dolphin-tool"),
+		input:gsub("'", "'\\''"),
+		(fsUtils.getDirectory(input).."/"..fsUtils.getFileNameNoExt(input)..".iso"):gsub("'", "'\\''")
+	)
+	logSystem.log("debug", "Running command : "..command)
+	os.execute(command)
+
+	logSystem.log("debug", "Deleting RVZ file...")
 	os.execute("rm '"..input.."'")
+
 	return "success"
 end
-
 
 return Compressor:new(compressorName, checkFunction, compressFunction, decompressFunction)

--- a/compressors/xz.lua
+++ b/compressors/xz.lua
@@ -37,7 +37,13 @@ local function compressFunction(input)
 	local ram = getMemoryToUse()
 
 	logSystem.log("info", "Compressing "..input.." using XZ with "..ram.."GB of RAM.")
-	os.execute(compressorManager.selectCompressionTool("xz").." -z9e --threads=0 --memlimit="..ram.."GB '"..input.."'")
+	local command = string.format("%s -z9e --threads=0 --memlimit=%sGB '%s'",
+		compressorManager.selectCompressionTool("xz"),
+		ram,
+		input:gsub("'", "'\\''")
+	)
+	logSystem.log("debug", "Running command : "..command)
+	os.execute(command)
 	return "success"
 end
 
@@ -45,7 +51,13 @@ local function decompressFunction(input)
 	local ram = getMemoryToUse()
 
 	logSystem.log("info", "Decompressing "..input.." using XZ with "..ram.."GB of RAM.")
-	os.execute(compressorManager.selectCompressionTool("xz").." -d --threads=0 --memlimit="..ram.."GB '"..input.."'")
+	local command = string.format("%s -d --threads=0 --memlimit=%sGB '%s'",
+		compressorManager.selectCompressionTool("xz"),
+		ram,
+		input:gsub("'", "'\\''")
+	)
+	logSystem.log("debug", "Running command : "..command)
+	os.execute(command)
 	return "success"
 end
 

--- a/compressors/xz.lua
+++ b/compressors/xz.lua
@@ -28,7 +28,10 @@ local function checkFunction()
 	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false) then
 		return "system"
 	else
-		logSystem.log("error", "XZ is somehow unavailable from your system. Due to it being considered critical, local cache installation will not be used.")
+		logSystem.log(
+			"error",
+			"XZ can't be provided by your system or locally. Default file compression/decompression support unavailable."
+		)
 		return "unavailable"
 	end
 end

--- a/compressors/xz.lua
+++ b/compressors/xz.lua
@@ -23,6 +23,7 @@ end
 -- Definitions
 local compressorName = "xz"
 local localVersion = nil
+
 local function checkFunction()
 	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false) then
 		return "system"
@@ -31,6 +32,7 @@ local function checkFunction()
 		return "unavailable"
 	end
 end
+
 local function compressFunction(input)
 	local ram = getMemoryToUse()
 
@@ -38,6 +40,7 @@ local function compressFunction(input)
 	os.execute(compressorManager.selectCompressionTool("xz").." -z9e --threads=0 --memlimit="..ram.."GB '"..input.."'")
 	return "success"
 end
+
 local function decompressFunction(input)
 	local ram = getMemoryToUse()
 

--- a/extra/help.lua
+++ b/extra/help.lua
@@ -9,7 +9,7 @@ Arguments :\
 	--version : Displays the version of the program.\
 	--ignore-system : Ignore system executables.\
 \
-	--normal-iso : Treat ISOs as normal files.\
+	--iso : Treat ISOs as normal files.\
 	--wii-gc : Treat ISOs as Wii/GameCube games.\
 "
 

--- a/extra/help.lua
+++ b/extra/help.lua
@@ -8,8 +8,9 @@ Arguments :\
 	--verbose : Enable debug messages.\
 	--version : Displays the version of the program.\
 	--ignore-system : Ignore system executables.\
+\
+	--normal-iso : Treat ISOs as normal files.\
+	--wii-gc : Treat ISOs as Wii/GameCube games.\
 "
---normal-iso : Treat ISOs as normal files.\
---wii-gc : Treat ISOs as Wii/GameCube games.\
 
 print(help)

--- a/install/archlinux/PKGBUILD
+++ b/install/archlinux/PKGBUILD
@@ -17,9 +17,9 @@ depends=(
 	'xz'
 )
 optdepends=(
-	'7z: Use 7z system installation for compression'
+	'p7zip: Use 7z system installation for compression'
+	'dolphin-emu: Enable Wii/GameCube compression through dolphin-tool'
 	'upx: (Not used yet) Use UPX system installation for compression'
-	'dolphin-emu: Use Dolphin Emulator system installation for compression'
 	'nsz: (Not used yet) Use NSZ system installation for compression'
 )
 makedepends=(git)

--- a/install/archlinux/PKGBUILD
+++ b/install/archlinux/PKGBUILD
@@ -19,7 +19,7 @@ depends=(
 optdepends=(
 	'7z: Use 7z system installation for compression'
 	'upx: (Not used yet) Use UPX system installation for compression'
-	'dolphin-emu: (Not used yet) Use Dolphin Emulator system installation for compression'
+	'dolphin-emu: Use Dolphin Emulator system installation for compression'
 	'nsz: (Not used yet) Use NSZ system installation for compression'
 )
 makedepends=(git)

--- a/modules/argumentManager.lua
+++ b/modules/argumentManager.lua
@@ -15,7 +15,7 @@ local arguments = {
 		require("extra.help")
 		os.exit(0)
 	end,
-	["--normal-iso"] = function()
+	["--iso"] = function()
 		if isoMode == nil then
 			logSystem.log("info", "ISOs will be treated normally.")
 			isoMode = "iso"

--- a/modules/argumentManager.lua
+++ b/modules/argumentManager.lua
@@ -28,7 +28,7 @@ local arguments = {
 		if isoMode == nil then
 			print("----------------------------------------------------------------------------")
 			print("WARNING ! StompMyFiles aims for pure brute strength, not performance !")
-			print("Wii/GameCube games compressed with it may not perform well or disfunction until decompression.")
+			print("Wii/GameCube games compressed with it may not perform well or malfunction until decompression.")
 			print("----------------------------------------------------------------------------")
 			io.write("Press Enter to confirm you've read this prompt.")
 			io.read()

--- a/modules/fsUtils.lua
+++ b/modules/fsUtils.lua
@@ -31,6 +31,17 @@ function fsUtils.getFileName(path)
 	end
 end
 
+-- Grab file name without extension
+function fsUtils.getFileNameNoExt(path)
+	local filename = fsUtils.getFileName(path)
+	local filenameWithoutExtension = filename:match("(.+)%..+")
+	if filenameWithoutExtension then
+		return filenameWithoutExtension
+	else
+		return filename
+	end
+end
+
 -- Grab directory
 function fsUtils.getDirectory(path)
 	local directory = path:match("^(.+)/[^/]+$")

--- a/modules/systemUtils.lua
+++ b/modules/systemUtils.lua
@@ -19,12 +19,13 @@ function systemUtils.checkPlatform()
 end
 
 function systemUtils.isInternetAvailable()
-	local internetTest = os.execute("ping -q -c 1 1.1.1.1")
+	local internetTest = os.execute("ping -q -c 1 1.1.1.1 &> /dev/null")
+
 	if internetTest == true then
 		logSystem.log("debug", "Internet connection is available.")
 		return true
 	else
-		logSystem.log("warning", "Internet connection is not available.")
+		logSystem.log("error", "Internet connection is not available.")
 		return false
 	end
 end

--- a/smf
+++ b/smf
@@ -20,4 +20,5 @@ if [ -x "$(command -v lua)" ]; then
 	lua $SCRIPT_PATH/smf.lua "$@"
 else
 	echo "No Lua installation found. Please install Lua and try again."
+	exit 1
 fi

--- a/smf.lua
+++ b/smf.lua
@@ -14,7 +14,7 @@ local compressors = {
 
 	-- Less common, but advantaged when used right.
 	-- ["upx"] = require("compressors.upx"),
-	-- ["dolphin-tool"] = require("compressors.dolphin-tool"),
+	["dolphin-tool"] = require("compressors.dolphin-tool")
 	-- ["nsz"] = require("compressors.nsz")
 }
 local bannedExtensions = require("extra.bannedExtensions")
@@ -105,6 +105,19 @@ for _,input in ipairs(ARGUMENTS.toBeCompressed) do
 			end,
 			["xz"] = function()
 				attemptOperation("xz", "decompress", input)
+			end,
+			["iso"] = function()
+				if ARGUMENTS.settings.isoMode == "wii_gc" then
+					attemptOperation("dolphin-tool", "compress", input)
+				elseif ARGUMENTS.settings.isoMode == "iso" then
+					attemptOperation("xz", "compress", input)
+				else
+					logSystem.log("warning", "No behavior specified for ISOs. Skipping...")
+					filesSkipped = filesSkipped + 1
+				end
+			end,
+			["rvz"] = function()
+				attemptOperation("dolphin-tool", "decompress", input)
 			end
 		}
 		local f = switch[extension]

--- a/smf.lua
+++ b/smf.lua
@@ -144,4 +144,4 @@ if (filesSkipped ~= 0) then
 	end
 end
 
-logSystem.log("debug", "Main function ended. Exiting program...")
+logSystem.log("info", "Exiting StompMyFiles...")


### PR DESCRIPTION
Right now, Dolphin's RVZ compression system is the most powerful way of reducing the size of Wii and GameCube games.
With the maximum settings (LZMA2, level 9, 2 Mio block size), I have received the following file size differences :

*Note : the default ISO file size is pretty much the same across all Wii and GameCube games depending on the original disc format. Because these ISO files are padded with useless data that RVZ manages well, without directly stripping it.*

| Game | ISO file size | SMF output | Percentage |
| - | - | - | - |
| Super Smash Bros Brawl. | 8.5 Go | 5.8 Go | 68 % |

As usual, SMF will aim for maximum compression ratio and brute strength, making these compressed games not optimized to be directly played. SMF will warn the user about this before beginning compression of ISO files with `--wii-gc` argument enabled.

All that's left to do is :
- [ ] Provide local installation system if easily possible (aka : don't download the entire emulator)