### PR TITLE
feat: Add nsz support for Nintendo Switch game compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ISO file specific options (if none of these are specified, StompMyFiles will ski
 | 7z | ✅ | ✅ | Folders |
 | xz | ❌ | ✅ | Default choice for single files |
 | dolphin-tool | ❌ | ✅ | Nintendo Wii / GameCube games (requires Dolphin Emulator to be installed) |
-| nsz | *Planned* | *Planned* | Nintendo Switch games |
+| nsz | *Planned* | ✅ | Nintendo Switch games |
 | upx | *Planned ?* | *Planned ?* | Executables |
 
 ## Compression Test Results

--- a/compressors/dolphin-tool.lua
+++ b/compressors/dolphin-tool.lua
@@ -6,7 +6,7 @@ local fsUtils = require("modules.fsUtils")
 
 -- Definitions
 local compressorName = "dolphin-tool"
-local localVersion = nil
+--local localVersion = nil
 
 local function checkFunction()
 	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false) then
@@ -33,11 +33,11 @@ local function compressFunction(input)
 	if os.execute(command) == true then
 		logSystem.log("debug", "Removing ISO file...")
 		os.remove(input:gsub("'", "'\\''"))
+		return "success"
 	else
 		logSystem.log("error", "dolphin-tool returned an error code. ISO file won't be removed.")
 		return "error"
 	end
-	return "success"
 end
 
 local function decompressFunction(input)
@@ -53,12 +53,11 @@ local function decompressFunction(input)
 	if os.execute(command) == true then
 		logSystem.log("debug", "Removing RVZ file...")
 		os.remove(input:gsub("'", "'\\''"))
+		return "success"
 	else
 		logSystem.log("error", "dolphin-tool returned an error code. RVZ file won't be removed.")
 		return "error"
 	end
-
-	return "success"
 end
 
 return Compressor:new(compressorName, checkFunction, compressFunction, decompressFunction)

--- a/compressors/nsz.lua
+++ b/compressors/nsz.lua
@@ -1,0 +1,80 @@
+-- Custom modules
+local logSystem = require("modules.logSystem")
+local Compressor = require("modules.compressorObject")
+local compressorManager = require("modules.compressorManager")
+local fsUtils = require("modules.fsUtils")
+local systemUtils = require("modules.systemUtils")
+
+-- Definitions
+local compressorName = "nsz"
+--local localVersion = nil
+
+local function checkFunction()
+	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false and ARGUMENTS.settings.switchSupport == true) then
+		return "system"
+	else
+		logSystem.log(
+			"error",
+			"nsz can't be provided by your system or locally. Nintendo Switch game support won't be available."
+		)
+		return "unavailable"
+	end
+end
+
+local function compressFunction(input)
+	--Get number of CPU threads
+	logSystem.log("debug", "Getting number of CPU threads for nsz...")
+	local threads = systemUtils.grabThreads()
+	logSystem.log("debug", "Got "..threads.." threads.")
+
+	-- Compression Command
+	logSystem.log("info", "Compressing "..input.." using nsz with "..threads.." threads.")
+
+	local command = string.format("%s -C -LSQK -l 22 -t %s --rm-source '%s'",
+		compressorManager.selectCompressionTool("nsz"),
+		threads,
+		input:gsub("'", "'\\''")
+	)
+	logSystem.log("debug", "Running command : "..command)
+
+	logSystem.log("switch", "Passing output to nsz...")
+	local result = os.execute(command)
+	logSystem.log("switchEnd")
+
+	if result == true then
+		return "success"
+	else
+		logSystem.log("error", "nsz returned an error code. Uncompressed Nintendo Switch game won't be removed.")
+		return "error"
+	end
+end
+
+local function decompressFunction(input)
+	--Get number of CPU threads
+	logSystem.log("debug", "Getting number of CPU threads for nsz...")
+	local threads = systemUtils.grabThreads()
+	logSystem.log("debug", "Got "..threads.." threads.")
+
+	-- Decompression Command
+	logSystem.log("info", "Decompressing "..input.." using nsz with "..threads.." threads.")
+
+	local command = string.format("%s -D -t %s --rm-source '%s'",
+		compressorManager.selectCompressionTool("nsz"),
+		threads,
+		input:gsub("'", "'\\''")
+	)
+	logSystem.log("debug", "Running command : "..command)
+
+	logSystem.log("switch", "Passing output to nsz...")
+	local result = os.execute(command)
+	logSystem.log("switchEnd")
+
+	if result == true then
+		return "success"
+	else
+		logSystem.log("error", "nsz returned an error code. Compressed Nintendo Switch game won't be removed.")
+		return "error"
+	end
+end
+
+return Compressor:new(compressorName, checkFunction, compressFunction, decompressFunction)

--- a/compressors/xz.lua
+++ b/compressors/xz.lua
@@ -22,7 +22,7 @@ end
 
 -- Definitions
 local compressorName = "xz"
-local localVersion = nil
+--local localVersion = nil
 
 local function checkFunction()
 	if (os.execute("which "..compressorName.." > /dev/null 2>&1") == true and ARGUMENTS.settings.ignoreSystemLibs == false) then
@@ -40,28 +40,40 @@ local function compressFunction(input)
 	local ram = getMemoryToUse()
 
 	logSystem.log("info", "Compressing "..input.." using XZ with "..ram.."GB of RAM.")
+	-- Compression Command
 	local command = string.format("%s -z9e --threads=0 --memlimit=%sGB '%s'",
 		compressorManager.selectCompressionTool("xz"),
 		ram,
 		input:gsub("'", "'\\''")
 	)
 	logSystem.log("debug", "Running command : "..command)
-	os.execute(command)
-	return "success"
+
+	if os.execute(command) then
+		return "success"
+	else
+		logSystem.log("error", "XZ returned an error code.")
+		return "error"
+	end
 end
 
 local function decompressFunction(input)
 	local ram = getMemoryToUse()
 
 	logSystem.log("info", "Decompressing "..input.." using XZ with "..ram.."GB of RAM.")
+	-- Decompression Command
 	local command = string.format("%s -d --threads=0 --memlimit=%sGB '%s'",
 		compressorManager.selectCompressionTool("xz"),
 		ram,
 		input:gsub("'", "'\\''")
 	)
 	logSystem.log("debug", "Running command : "..command)
-	os.execute(command)
-	return "success"
+
+	if os.execute(command) then
+		return "success"
+	else
+		logSystem.log("error", "XZ returned an error code.")
+		return "error"
+	end
 end
 
 

--- a/extra/help.lua
+++ b/extra/help.lua
@@ -9,8 +9,12 @@ Arguments :\
 	--version : Displays the version of the program.\
 	--ignore-system : Ignore system executables.\
 \
+ISO support :\
 	--iso : Treat ISOs as normal files.\
 	--wii-gc : Treat ISOs as Wii/GameCube games.\
+\
+Nintendo Switch support :\
+	--enable-switch : Enable experimental Nintendo Switch game support.\
 "
 
 print(help)

--- a/install/archlinux/PKGBUILD
+++ b/install/archlinux/PKGBUILD
@@ -20,8 +20,7 @@ depends=(
 optdepends=(
 	'p7zip: Use 7z system installation for compression'
 	'dolphin-emu: Enable Wii/GameCube compression through dolphin-tool'
-	'upx: (Not used yet) Use UPX system installation for compression'
-	'nsz: (Not used yet) Use NSZ system installation for compression'
+	'nsz: Use NSZ system installation for compression'
 )
 makedepends=(git)
 provides=("${pkgname%-git}")

--- a/modules/argumentManager.lua
+++ b/modules/argumentManager.lua
@@ -9,9 +9,39 @@ local isoMode = nil
 
 local ignoreSystemLibs = false -- Determines whether or not to ignore system libraries.
 local verboseEnabled = false -- Determines whether or not to print debug messages.
+local enableSwitchSupport = false -- Determines whether or not to enable Nintendo Switch support.
 
 -- First, we give each argument an action.
 local arguments = {
+	["--enable-switch"] = function ()
+		if fsUtils.exists(os.getenv("HOME").."/.switch/prod.keys") then
+			if enableSwitchSupport == false then
+				logSystem.log("info", "Nintendo Switch production keys successfully located.")
+				print()
+				print("----------------------------------------------------------------------------")
+				print("WARNING ! Nintendo Switch game support is still experimental !")
+				print("Expect the operation to use A TON of memory.")
+				print("Do not proceed if you do not think your computer can handle it.")
+				print("Tip : zRAM can help with the operation. Enable it if possible.")
+				print("----------------------------------------------------------------------------")
+				io.write("Press Enter to confirm you've read this prompt.")
+				io.read()
+				print()
+
+				print("Are you sure ? This compression system is very memory intensive and may take a long time to complete.")
+				print("Even a computer with 16 GB of RAM and 16 GB of zRAM can run out of memory.")
+				io.write("Press Enter if you're certain you want to continue.")
+				io.read()
+				print()
+				
+				enableSwitchSupport = true
+				logSystem.log("warning", "Nintendo Switch game support enabled. Good luck !")
+			end
+		else
+			logSystem.log("error", "Nintendo Switch keys not found. Please put them as ~/.switch/prod.keys and try again.")
+			os.exit(1)
+		end
+	end,
 	["--ignore-system"] = function ()
 		ignoreSystemLibs = true
 	end,
@@ -103,5 +133,6 @@ end
 return {toBeCompressed = toBeCompressed, settings = {
 	isoMode = isoMode,
 	ignoreSystemLibs = ignoreSystemLibs,
-	verboseEnabled = verboseEnabled
+	verboseEnabled = verboseEnabled,
+	switchSupport = enableSwitchSupport
 }}

--- a/modules/systemUtils.lua
+++ b/modules/systemUtils.lua
@@ -40,4 +40,14 @@ function systemUtils.isInternetAvailable()
 	end
 end
 
+function systemUtils.grabThreads()
+	local f = io.popen("cat /proc/cpuinfo | grep processor | wc -l")
+	if (not f) then
+		error("Could not get the number of CPU threads.")
+	end
+	local threads = f:read("*a")
+	f:close()
+	return tonumber(threads)
+end
+
 return systemUtils


### PR DESCRIPTION
I'm not certain yet this pull request will be implemented. Few games have shown efficient compression, and for now, in the case of one game, I was unable to recreate the original file from the compressed version. It's not impossible I simply have a bad dump.
I made it disabled by default, due to the compression sometimes being too heavy for systems to handle, and the aforementioned issues.

Noteworthy results :

| Game | Original size | Compressed size | Percentage | Decompressed size | Identical |
| ------ | -------------- | ------------------ | ------------- | --------------------- | --------- |
| Super Smash Bros. Ultimate | 16 GB | 11.5 GB | 72 % | 14.5 GB | ❌ |